### PR TITLE
Use dist for build location

### DIFF
--- a/lib/ms.js
+++ b/lib/ms.js
@@ -11,12 +11,15 @@ const assign = Object.assign
  */
 
 function docpress (cwd, options) {
-  let meta = { docs: 'docs' }
+  let meta = {
+    docs: 'docs',
+    dist: '_docpress'
+  }
   assign(meta, loadConfig(cwd, meta.docs))
 
   let app = Metalsmith(cwd)
     .source('.')
-    .destination('_docpress')
+    .destination(meta.dist)
     .metadata(meta)
     .ignore(`!**/{${meta.docs}{,/**/*},*.md}`)
 


### PR DESCRIPTION
Allow setting `dist` in the `docpress.json` to set where the build is placed. This defaults to `'_docpress'` if not set.

I also wrote a PR for the docs configuration section.