### PR TITLE
Ignore node_modules for metalsmith

### DIFF
--- a/lib/ms.js
+++ b/lib/ms.js
@@ -21,6 +21,7 @@ function docpress (cwd, options) {
     .source('.')
     .destination(meta.dist)
     .metadata(meta)
+    .ignore('node_modules')
     .ignore(`!**/{${meta.docs}{,/**/*},*.md}`)
 
   return app


### PR DESCRIPTION
Prevent metalsmith from crashing docpress by ignoring `node_modules`. Might be a good idea
to add an option to pass through ignore options, just in case people have big projects or something similar.

Resolves https://github.com/docpress/docpress/issues/113