### PR TITLE
Use site title in page titles

### DIFF
--- a/lib/indexify.js
+++ b/lib/indexify.js
@@ -18,6 +18,7 @@ module.exports = function indexify (toc) {
       sources[item.source] = item.url
       index[item.url] = {
         source: item.source,
+        sectionTitle: item.title,
         title: rootTitle !== item.title ? `${item.title} - ${rootTitle}` : item.title,
         slug: item.slug
       }

--- a/lib/indexify.js
+++ b/lib/indexify.js
@@ -9,15 +9,16 @@
 module.exports = function indexify (toc) {
   const index = {}
   const sources = {}
-  walk(toc)
+  const title = toc.sections[0].title
+  walk(toc, title)
   return { index, sources }
 
-  function walk (item) {
+  function walk (item, rootTitle) {
     if (item.url) {
       sources[item.source] = item.url
       index[item.url] = {
         source: item.source,
-        title: item.title,
+        title: rootTitle !== item.title ? `${item.title} - ${rootTitle}` : item.title,
         slug: item.slug
       }
 
@@ -25,7 +26,7 @@ module.exports = function indexify (toc) {
     }
 
     if (item.sections) {
-      item.sections.forEach((s) => walk(s))
+      item.sections.forEach((s) => walk(s, rootTitle))
     }
   }
 }

--- a/test/indexify_test.js
+++ b/test/indexify_test.js
@@ -33,13 +33,13 @@ describe('indexify', function () {
     const res = indexify(toc)
     expect(res.index).toEqual({
       'install.html': {
-        source: 'docs/install.md', title: 'Install - Readme', slug: 'install'
+        source: 'docs/install.md', title: 'Install - Readme', sectionTitle: 'Install', slug: 'install'
       },
       'usage.html': {
-        source: 'docs/usage.md', title: 'Usage - Readme', slug: 'usage'
+        source: 'docs/usage.md', title: 'Usage - Readme', sectionTitle: 'Usage', slug: 'usage'
       },
       'index.html': {
-        source: 'README.md', title: 'Readme', slug: 'index'
+        source: 'README.md', title: 'Readme', sectionTitle: 'Readme', slug: 'index'
       }
     })
   })

--- a/test/indexify_test.js
+++ b/test/indexify_test.js
@@ -33,10 +33,10 @@ describe('indexify', function () {
     const res = indexify(toc)
     expect(res.index).toEqual({
       'install.html': {
-        source: 'docs/install.md', title: 'Install', slug: 'install'
+        source: 'docs/install.md', title: 'Install - Readme', slug: 'install'
       },
       'usage.html': {
-        source: 'docs/usage.md', title: 'Usage', slug: 'usage'
+        source: 'docs/usage.md', title: 'Usage - Readme', slug: 'usage'
       },
       'index.html': {
         source: 'README.md', title: 'Readme', slug: 'index'


### PR DESCRIPTION
For example my site is called "Ilya's Docs" and I have a section called
"API". The full title will be "API - Ilya's Docs", unless the section is the
same name as the title.

This gives subsections more of a context when open in a tab.

---

### TODO

- [x] Make sure to not add root title to bottom next/previous titles (https://github.com/docpress/docpress-base/pull/135)
- [x] Fix tests

Ready for merge.