### PR TITLE
Improve caching implementation using lru-cache

### DIFF
--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -1,36 +1,22 @@
 'use strict'
 
-let cache = {}
-let hits = []
+const LRU = require('lru-cache')
+let cache = LRU(500)
 
-function memoize (keyObject, fn) {
+/**
+ * Memoizes the result of `fn()`.
+ *
+ * If it's been invoked recently, the last known result will be returned. This
+ * is used to cache expensive calls such as Markdown parsing.
+ *
+ *     html = memoize('hello', () => markdown('a long string goes here'))
+ */
+
+module.exports = function memoize (keyObject, fn) {
   const key = JSON.stringify(keyObject)
-  if (cache[key]) return cache[key]
-  cache[key] = fn()
-  hits.push(key)
-  return cache[key]
+  if (cache.has(key)) return cache.get(key)
+
+  const val = fn()
+  cache.set(key, val)
+  return val
 }
-
-// Ensure that the last X keys are always available
-memoize.keepKeys = 20
-
-// Truncate every now and then
-memoize.truncateInterval = 3 * 60 * 1000
-
-// truncate the cache to the last N keys used
-memoize.prune = function prune () {
-  const preserved = hits.slice(hits.length - memoize.keepKeys)
-  const newCache = {}
-
-  preserved.forEach((key) => {
-    newCache[key] = cache[key]
-  })
-
-  hits = preserved
-  cache = newCache
-}
-
-// truncate every few minutes
-memoize.timer = setInterval(memoize.prune, memoize.truncateInterval)
-
-module.exports = memoize

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "debug": "2.2.0",
     "highlight.js": "9.5.0",
     "lodash": "3.10.1",
+    "lru-cache": "4.0.1",
     "markdown-it": "7.0.1",
     "markdown-it-decorate": "1.2.1",
     "marked": "0.3.5",


### PR DESCRIPTION
Docpress caches some markdown parsing using a crappy memoize() implementation.

This improves that implementation by using [lru-cache](https://www.npmjs.com/package/lru-cache).